### PR TITLE
Fix CleanWebpackPlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -89,7 +89,9 @@ const config = {
   },
   plugins: [
     new VueLoaderPlugin(),
-    new CleanWebpackPlugin(),
+    new CleanWebpackPlugin({
+      cleanStaleWebpackAssets: false,
+    }),
     new CopyWebpackPlugin([
       { from: 'assets', to: 'assets' },
       { from: 'manifest.json', to: 'manifest.json', flatten: true },


### PR DESCRIPTION
Add cleanStaleWebpackAssets option to CleanWebpackPlugin to avoid manifest.json from being deleted on reload.

See [webpack-contrib/copy-webpack-plugin#385](https://github.com/webpack-contrib/copy-webpack-plugin/issues/385) and [johnagan/clean-webpack-plugin#125](https://github.com/johnagan/clean-webpack-plugin/issues/125)
