### PR TITLE
Webpack extension reloader update

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "vue-style-loader": "^4.1.2",
     "vue-template-compiler": "^2.6.10",
     "webpack": "^4.41.2",
-    "webpack-chrome-extension-reloader": "^1.3.0",
-    "webpack-cli": "^3.3.10"
+    "webpack-cli": "^3.3.10",
+    "webpack-extension-reloader": "^1.1.4"
   },
   "license": "MIT",
   "name": "vue-chrome-extension-boilerplate",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,7 +3,7 @@ const webpack = require('webpack')
 const fg = require('fast-glob')
 const CopyWebpackPlugin = require('copy-webpack-plugin')
 const { CleanWebpackPlugin } = require('clean-webpack-plugin')
-const ChromeExtensionReloader = require('webpack-chrome-extension-reloader')
+const ExtensionReloader = require('webpack-extension-reloader')
 const HtmlWebpackPlugin = require('html-webpack-plugin')
 const VueLoaderPlugin = require('vue-loader/lib/plugin')
 const ScriptExtHtmlWebpackPlugin = require('script-ext-html-webpack-plugin')
@@ -117,13 +117,11 @@ const config = {
 if (isDevMode) {
   config.plugins.push(
     new webpack.HotModuleReplacementPlugin(),
-    new ChromeExtensionReloader({
-      entries: {
-        background: 'background',
-        options: 'options',
-        popup: 'popup',
-        contentScripts: 'contentScripts/index',
-      },
+    new ExtensionReloader({
+      contentScript: 'contentScripts',
+      background: 'background',
+      extensionPage: 'popup',
+      options: 'options',
     })
   )
 } else {


### PR DESCRIPTION
Webpack Chrome Extension Reloader is no longer maintained, development has moved to Webpack Extension Reloader.
https://github.com/rubenspgcavalcante/webpack-extension-reloader