### PR TITLE
Fixed output publicPath, image loader

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ function configFunc(env, argv) {
     },
     output: {
       path: path.resolve(__dirname, './dist'),
-      publicPath: '.',
+      publicPath: './',
       filename: '[name].js',
     },
     module: {
@@ -81,6 +81,7 @@ function configFunc(env, argv) {
           loader: 'file-loader',
           options: {
             name: '[name].[ext]?[hash]',
+            esModule: false
           },
         },
       ],


### PR DESCRIPTION
output.publicPath was changed to './' (it was '.', which erroneously prepended '.' to the filename)
I added esModule = false to the image loader as per https://stackoverflow.com/a/59115624