### PR TITLE
refactor: use version number in manifest.json as zip file name

### DIFF
--- a/scripts/build-zip.js
+++ b/scripts/build-zip.js
@@ -5,7 +5,7 @@ const path = require('path')
 // eslint-disable-next-line
 var archiver = require('archiver')
 
-const extPackageJson = require('../package.json')
+const extPackageJson = require('../src/manifest.json')
 
 const DEST_DIR = path.join(__dirname, '../dist')
 const DEST_ZIP_DIR = path.join(__dirname, '../dist-zip')


### PR DESCRIPTION
most of the time, when we need to update an extension that already in Chrome web store, we need to update the version number in `manifest.json`.
we don't need to update the version number in `package.json`.
So I think to use the version number in manifest.json as part of the zip file name makes more sense and convenient.