### PR TITLE
Fix content scripts auto reload

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -125,10 +125,12 @@ function configFunc(env, argv) {
     config.plugins.push(
       new webpack.HotModuleReplacementPlugin(),
       new ExtensionReloader({
-        contentScript: 'contentScripts',
-        background: 'background',
-        extensionPage: 'popup',
-        options: 'options',
+        entries: {
+          contentScript: 'contentScripts',
+          background: 'background',
+          extensionPage: 'popup',
+          options: 'options',
+        }
       })
     )
   } else {


### PR DESCRIPTION
All entries should be in "entries" object according to plugin documentation https://github.com/rubenspgcavalcante/webpack-extension-reloader